### PR TITLE
Implement bundle writer

### DIFF
--- a/bundle_writer.go
+++ b/bundle_writer.go
@@ -27,7 +27,7 @@ func (w *bundleWriter) SetHeight(val int) error {
 	}
 
 	chunkHeight := val - (val % w.chunkSize)
-	if chunkHeight == w.chunkHeight {
+	if chunkHeight == w.chunkHeight && w.file != nil {
 		return nil
 	}
 

--- a/bundle_writer.go
+++ b/bundle_writer.go
@@ -1,0 +1,70 @@
+package extractor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+type bundleWriter struct {
+	filename    string
+	file        *os.File
+	height      int
+	chunkSize   int
+	chunkHeight int
+}
+
+func NewBundleWriter(filename string, chunkSize int) Writer {
+	return &bundleWriter{
+		filename:  filename,
+		chunkSize: chunkSize,
+	}
+}
+
+func (w *bundleWriter) SetHeight(val int) error {
+	if w.chunkSize == 0 {
+		return errors.New("chunk size is zero")
+	}
+
+	chunkHeight := val - (val % w.chunkSize)
+	if chunkHeight == w.chunkHeight {
+		return nil
+	}
+
+	w.chunkHeight = chunkHeight
+	return w.prepareOutput()
+}
+
+func (w *bundleWriter) prepareOutput() error {
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	filename := fmt.Sprintf("%s.%010d", w.filename, w.chunkHeight)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0666)
+	if err != nil {
+		return err
+	}
+	w.file = file
+
+	return nil
+}
+
+func (w *bundleWriter) WriteLine(data string) error {
+	if w.file == nil {
+		return errors.New("output file is not initialized")
+	}
+
+	_, err := fmt.Fprintf(w.file, "%s\n", data)
+	return err
+}
+
+func (w *bundleWriter) Close() error {
+	if w.file == nil {
+		return nil
+	}
+	if err := w.file.Sync(); err != nil {
+		return err
+	}
+	return w.file.Close()
+}

--- a/bundle_writer_test.go
+++ b/bundle_writer_test.go
@@ -1,0 +1,33 @@
+package extractor
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundleWriter(t *testing.T) {
+	basePath := fmt.Sprintf("/tmp/%v", time.Now().Unix())
+
+	writer := NewBundleWriter(basePath, 0)
+	assert.Equal(t, writer.SetHeight(0).Error(), "chunk size is zero")
+
+	writer = NewBundleWriter(basePath, 1000)
+	assert.NoError(t, writer.SetHeight(0))
+	assert.True(t, fileExists(basePath+".0000000000"))
+
+	writer.SetHeight(100)
+	assert.True(t, fileExists(basePath+".0000000000"))
+	assert.False(t, fileExists(basePath+".0000001000"))
+
+	writer.SetHeight(1234)
+	assert.True(t, fileExists(basePath+".0000001000"))
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/bundle_writer_test.go
+++ b/bundle_writer_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -12,22 +13,42 @@ import (
 func TestBundleWriter(t *testing.T) {
 	basePath := fmt.Sprintf("/tmp/%v", time.Now().Unix())
 
-	writer := NewBundleWriter(basePath, 0)
-	assert.Equal(t, writer.SetHeight(0).Error(), "chunk size is zero")
+	t.Run("file creation", func(t *testing.T) {
+		writer := NewBundleWriter(basePath, 0)
+		assert.Equal(t, writer.SetHeight(0).Error(), "chunk size is zero")
 
-	writer = NewBundleWriter(basePath, 1000)
-	assert.NoError(t, writer.SetHeight(0))
-	assert.True(t, fileExists(basePath+".0000000000"))
+		writer = NewBundleWriter(basePath, 1000)
+		assert.NoError(t, writer.SetHeight(0))
+		assert.True(t, fileExists(basePath+".0000000000"))
 
-	writer.SetHeight(100)
-	assert.True(t, fileExists(basePath+".0000000000"))
-	assert.False(t, fileExists(basePath+".0000001000"))
+		writer.SetHeight(100)
+		assert.True(t, fileExists(basePath+".0000000000"))
+		assert.False(t, fileExists(basePath+".0000001000"))
 
-	writer.SetHeight(1234)
-	assert.True(t, fileExists(basePath+".0000001000"))
+		writer.SetHeight(1234)
+		assert.True(t, fileExists(basePath+".0000001000"))
+	})
+
+	t.Run("writing", func(t *testing.T) {
+		writer := NewBundleWriter(basePath, 1000)
+		assert.Equal(t, writer.WriteLine("test").Error(), "output file is not initialized")
+
+		assert.NoError(t, writer.SetHeight(0))
+		assert.NoError(t, writer.WriteLine("test"))
+		assert.NoError(t, writer.WriteLine("test2"))
+		assert.Equal(t, "test\ntest2\n", fileContent(basePath+".0000000000"))
+	})
 }
 
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+func fileContent(path string) string {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -15,3 +15,27 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, int64(0), config.EndHeight)
 	assert.Equal(t, "", config.RootDir)
 }
+
+func TestValidate(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		config := Config{}
+
+		assert.NoError(t, config.Validate())
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		config := Config{}
+
+		assert.NoError(t, config.Validate())
+		assert.Equal(t, false, config.Enabled)
+		assert.Equal(t, "STDOUT", config.OutputFile)
+	})
+
+	t.Run("stdout grouping", func(t *testing.T) {
+		config := Config{
+			Enabled: true,
+			Bundle:  true,
+		}
+		assert.Equal(t, "cant use output grouping with STDOUT", config.Validate().Error())
+	})
+}

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package extractor
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -36,6 +37,23 @@ func TestValidate(t *testing.T) {
 			Enabled: true,
 			Bundle:  true,
 		}
-		assert.Equal(t, "cant use output grouping with STDOUT", config.Validate().Error())
+		assert.Equal(t, "cant use bundling with STDOUT", config.Validate().Error())
 	})
+}
+
+func TestGetOutputFile(t *testing.T) {
+	examples := []struct {
+		input    string
+		expected string
+	}{
+		{"file", "file"},
+		{"file-$date", "file-" + time.Now().UTC().Format("20060102")},
+		{"file-$time", "file-" + time.Now().UTC().Format("150405")},
+		{"file-$ts", "file-" + time.Now().UTC().Format("20060102-150405")},
+	}
+
+	for _, ex := range examples {
+		config := Config{OutputFile: ex.input}
+		assert.Equal(t, ex.expected, config.GetOutputFile())
+	}
 }

--- a/console_writer.go
+++ b/console_writer.go
@@ -1,0 +1,29 @@
+package extractor
+
+import (
+	"fmt"
+	"io"
+)
+
+type consoleWriter struct {
+	dst io.Writer
+}
+
+func NewConsoleWriter(dst io.Writer) Writer {
+	return &consoleWriter{
+		dst: dst,
+	}
+}
+
+func (c consoleWriter) SetHeight(height int) error {
+	return nil
+}
+
+func (w consoleWriter) WriteLine(data string) error {
+	_, err := fmt.Fprintf(w.dst, "%s\n", data)
+	return err
+}
+
+func (w consoleWriter) Close() error {
+	return nil
+}

--- a/extractor.go
+++ b/extractor.go
@@ -139,15 +139,22 @@ func (ex *ExtractorService) initStreamOutput() error {
 
 	if ex.config.Bundle {
 		ex.writer = NewBundleWriter(filename, ex.config.BundleSize)
-	} else {
-		switch filename {
-		case "", "stdout", "STDOUT":
-			ex.writer = NewConsoleWriter(os.Stdout)
-		case "stderr", "STDERR":
-			ex.writer = NewConsoleWriter(os.Stderr)
-		default:
-			ex.writer = NewFileWriter(filename)
-		}
+
+		ex.Logger.Info("configured stream output",
+			"dest", filename,
+			"bundle", ex.config.Bundle,
+			"bundle_size", ex.config.BundleSize,
+		)
+		return nil
+	}
+
+	switch filename {
+	case "", "stdout", "STDOUT":
+		ex.writer = NewConsoleWriter(os.Stdout)
+	case "stderr", "STDERR":
+		ex.writer = NewConsoleWriter(os.Stderr)
+	default:
+		ex.writer = NewFileWriter(filename)
 	}
 
 	ex.Logger.Info("configured stream output", "dest", filename)

--- a/extractor.go
+++ b/extractor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"os"
 	"sync"
 
 	//	cc "github.com/figment-networks/extractor-tendermint/codec"
@@ -139,7 +140,14 @@ func (ex *ExtractorService) initStreamOutput() error {
 	if ex.config.Bundle {
 		ex.writer = NewBundleWriter(filename, ex.config.BundleSize)
 	} else {
-		ex.writer = NewFileWriter(filename)
+		switch filename {
+		case "", "stdout", "STDOUT":
+			ex.writer = NewConsoleWriter(os.Stdout)
+		case "stderr", "STDERR":
+			ex.writer = NewConsoleWriter(os.Stderr)
+		default:
+			ex.writer = NewFileWriter(filename)
+		}
 	}
 
 	ex.Logger.Info("configured stream output", "dest", filename)

--- a/file_writer.go
+++ b/file_writer.go
@@ -1,0 +1,58 @@
+package extractor
+
+import (
+	"fmt"
+	"os"
+)
+
+type fileWriter struct {
+	filename string
+	file     *os.File
+}
+
+func NewFileWriter(filename string) Writer {
+	return &fileWriter{
+		filename: filename,
+	}
+}
+
+func (w *fileWriter) SetHeight(height int) error {
+	return nil
+}
+
+func (w *fileWriter) WriteLine(data string) error {
+	if w.file == nil {
+		if err := w.prepareOutput(); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintf(w.file, "%s\n", data)
+	return err
+}
+
+func (w *fileWriter) Close() error {
+	if w.file == nil {
+		return nil
+	}
+	if err := w.file.Sync(); err != nil {
+		return nil
+	}
+	return w.file.Close()
+}
+
+func (w *fileWriter) prepareOutput() error {
+	switch w.filename {
+	case "", "stdout", "STDOUT":
+		w.file = os.Stdout
+	case "stderr", "STDERR":
+		w.file = os.Stderr
+	default:
+		file, err := os.OpenFile(w.filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0666)
+		if err != nil {
+			return err
+		}
+		w.file = file
+	}
+	return nil
+}

--- a/file_writer.go
+++ b/file_writer.go
@@ -42,17 +42,11 @@ func (w *fileWriter) Close() error {
 }
 
 func (w *fileWriter) prepareOutput() error {
-	switch w.filename {
-	case "", "stdout", "STDOUT":
-		w.file = os.Stdout
-	case "stderr", "STDERR":
-		w.file = os.Stderr
-	default:
-		file, err := os.OpenFile(w.filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0666)
-		if err != nil {
-			return err
-		}
-		w.file = file
+	file, err := os.OpenFile(w.filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY|os.O_SYNC, 0666)
+	if err != nil {
+		return err
 	}
+
+	w.file = file
 	return nil
 }

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,12 @@
+package extractor
+
+type Writer interface {
+	SetHeight(height int) error
+	WriteLine(data string) error
+	Close() error
+}
+
+var (
+	_ Writer = (*bundleWriter)(nil)
+	_ Writer = (*fileWriter)(nil)
+)

--- a/writer.go
+++ b/writer.go
@@ -9,4 +9,5 @@ type Writer interface {
 var (
 	_ Writer = (*bundleWriter)(nil)
 	_ Writer = (*fileWriter)(nil)
+	_ Writer = (*consoleWriter)(nil)
 )


### PR DESCRIPTION
This adds support for bundled log files. So far we will have these options:

- Log output to STDOUT/STDERR (default).
- Log output to a single file, with some minimal filename templating (ie `stream-$date`, `stream-$time`).
- Log output to bundled files. Bundle size is configurable. Example: `stream.log.00000xxxxx`

Bundled output configuration:

```toml
[extractor]
enabled = true
output_file = "extractor/stream.log"
bundle = true
bundle_size = 1000 # will save 1k blocks per file
```

Example list:

```
-rw-r--r--  1 sosedoff  staff    2430938 Nov 10 17:57 stream.log.0005236900
-rw-r--r--  1 sosedoff  staff    4479136 Nov 10 17:58 stream.log.0005237000
-rw-r--r--  1 sosedoff  staff    4468652 Nov 10 18:00 stream.log.0005237100
-rw-r--r--  1 sosedoff  staff    2789838 Nov 10 18:00 stream.log.0005237200
```