### PR TITLE
Add internal extractor stream termination

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -224,7 +224,7 @@ func (ex *ExtractorService) indexTX(result *abci.TxResult) error {
 
 func (ex *ExtractorService) indexBlock(bh types.EventDataNewBlock) error {
 	if ex.terminated {
-		ex.Logger.Error("can't index tx, stream is terminated", "err", ex.terminatedErr)
+		ex.Logger.Error("can't index block, stream is terminated", "err", ex.terminatedErr)
 		return nil
 	}
 

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -3,7 +3,6 @@ package extractor
 import (
 	"bytes"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -127,11 +126,10 @@ func TestIndexBlock(t *testing.T) {
 
 	for _, ex := range examples {
 		output := bytes.NewBuffer(nil)
-		writer := NewConsoleWriter(output)
+		extractor := NewExtractorService(nil, nil)
+		extractor.writer = NewConsoleWriter(output)
 
-		lock := &sync.Mutex{}
-
-		err := indexBlock(writer, lock, ex.input)
+		err := extractor.indexBlock(ex.input)
 		if err != nil {
 			assert.Equal(t, err.Error(), ex.err)
 		}
@@ -161,10 +159,10 @@ func TestIndexTx(t *testing.T) {
 
 	for _, ex := range examples {
 		output := bytes.NewBuffer(nil)
-		writer := NewConsoleWriter(output)
-		lock := &sync.Mutex{}
+		extractor := NewExtractorService(nil, nil)
+		extractor.writer = NewConsoleWriter(output)
 
-		err := indexTX(writer, lock, ex.input)
+		err := extractor.indexTX(ex.input)
 		if err != nil {
 			assert.Equal(t, err.Error(), ex.err)
 		}


### PR DESCRIPTION
One way to handle any extraction issues without affecting the output stream (skipping block /tx data, etc).
The node may continue with its business, but the extractor will keep erroring out. Such error messages could be spotted by monitoring systems.

Alternative way to handle termination is to place flags within the node and let it exit on a problematic height. 