### PR TITLE
Initialize top level block data / evidence by default

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -255,6 +255,8 @@ func indexBlock(out Writer, sync *sync.Mutex, bh types.EventDataNewBlock) error 
 				BlockId:    mapBlockID(bh.Block.LastCommit.BlockID),
 				Signatures: []*codec.CommitSig{}, // TODO(lukanus): do it properly
 			},
+			Evidence: &codec.EvidenceList{},
+			Data:     &codec.Data{},
 		},
 	}
 
@@ -267,14 +269,12 @@ func indexBlock(out Writer, sync *sync.Mutex, bh types.EventDataNewBlock) error 
 	}
 
 	if len(bh.Block.Data.Txs) > 0 {
-		nb.Block.Data = &codec.Data{}
 		for _, tx := range bh.Block.Data.Txs {
 			nb.Block.Data.Txs = append(nb.Block.Data.Txs, tx)
 		}
 	}
 
 	if len(bh.Block.Evidence.Evidence) > 0 {
-		nb.Block.Evidence = &codec.EvidenceList{}
 		for _, ev := range bh.Block.Evidence.Evidence {
 
 			newEv := &codec.Evidence{}

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -69,7 +69,7 @@ func TestIndexBlock(t *testing.T) {
 					},
 				},
 			},
-			expected: "DMLOG BLOCK 1 1634674166000 CiYKHAoAEghjaGFpbi1pZBgBIgYI9su8iwYqAhIAcgAiBhoEEgIIARICEgA=\n",
+			expected: "DMLOG BLOCK 1 1634674166000 CioKHAoAEghjaGFpbi1pZBgBIgYI9su8iwYqAhIAcgASABoAIgYaBBICCAESAhIA\n",
 		},
 		{
 			input: types.EventDataNewBlock{
@@ -122,7 +122,7 @@ func TestIndexBlock(t *testing.T) {
 					},
 				},
 			},
-			expected: "DMLOG BLOCK 2 1634674166000 CiYKHAoAEghjaGFpbi1pZBgCIgYI9su8iwYqAhIAcgAiBhoEEgIIARICEgAaPAocCgpldmVudFR5cGUxEg4KBGtleTESBnZhbHVlMQocCgpldmVudFR5cGUyEg4KBGtleTESBnZhbHVlMSI+EgAaHAoKZXZlbnRUeXBlMRIOCgRrZXkxEgZ2YWx1ZTEaHAoKZXZlbnRUeXBlMhIOCgRrZXkxEgZ2YWx1ZTE=\n",
+			expected: "DMLOG BLOCK 2 1634674166000 CioKHAoAEghjaGFpbi1pZBgCIgYI9su8iwYqAhIAcgASABoAIgYaBBICCAESAhIAGjwKHAoKZXZlbnRUeXBlMRIOCgRrZXkxEgZ2YWx1ZTEKHAoKZXZlbnRUeXBlMhIOCgRrZXkxEgZ2YWx1ZTEiPhIAGhwKCmV2ZW50VHlwZTESDgoEa2V5MRIGdmFsdWUxGhwKCmV2ZW50VHlwZTISDgoEa2V5MRIGdmFsdWUx\n",
 		},
 	}
 


### PR DESCRIPTION
Changes to deal with graph-node requiring both data/evidence attributes. If they could be omitted via rust bindings then we wont need the PR. 